### PR TITLE
Add doc_dir config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ After the installation you can configure the plugin by adding the following to y
 ```lua
 require('adr').setup({
     template_dir = "~/adr-templates",
+    doc_dir = "/docs/",
 })
 ```
 
 If not `template_dir` is specified the default templates within this repository will be used.
+
+Configuring the `doc_dir` parameter allows you to configure where newly created markdown files will be placed.
 
 Then create a keybinding, that calls `require('adr').create_from_template()`.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After the installation you can configure the plugin by adding the following to y
 ```lua
 require('adr').setup({
     template_dir = "~/adr-templates",
-    doc_dir = "/docs/",
+    doc_dir = "docs",
 })
 ```
 

--- a/lua/adr/init.lua
+++ b/lua/adr/init.lua
@@ -64,12 +64,13 @@ end
 
 M.write_to_path = function(template_name, file_name)
     local template = vim.fn.readfile(template_name)
+    local doc_dir_path = vim.fn.getcwd() .. '/' .. M.config.doc_dir
 
-    if vim.fn.isdirectory(vim.fn.getcwd() .. M.config.doc_dir) == 0 then
-        vim.fn.mkdir(vim.fn.getcwd() .. M.config.doc_dir, 'p')
+    if vim.fn.isdirectory(doc_dir_path) == 0 then
+        vim.fn.mkdir(doc_dir_path, 'p')
     end
 
-    local file = vim.fn.getcwd() .. M.config.doc_dir .. '/' .. file_name .. '.md'
+    local file = doc_dir_path .. '/' .. file_name .. '.md'
     if not file_exists(file) then
         vim.fn.writefile(template, file)
     end

--- a/lua/adr/init.lua
+++ b/lua/adr/init.lua
@@ -11,11 +11,15 @@ end
 
 M.config = {
     template_dir = vim.fs.dirname(debug.getinfo(1).source:sub(2)) .. "/../../templates",
+    doc_dir = '/docs',
 }
 
 M.setup = function(config)
     if config['template_dir'] ~= nil then
         M.config.template_dir = config['template_dir']
+    end
+    if config['doc_dir'] ~= nil then
+        M.config.doc_dir = config['doc_dir']
     end
 end
 
@@ -61,11 +65,11 @@ end
 M.write_to_path = function(template_name, file_name)
     local template = vim.fn.readfile(template_name)
 
-    if vim.fn.isdirectory(vim.fn.getcwd() .. '/docs') == 0 then
-        vim.fn.mkdir(vim.fn.getcwd() .. '/docs')
+    if vim.fn.isdirectory(vim.fn.getcwd() .. M.config.doc_dir) == 0 then
+        vim.fn.mkdir(vim.fn.getcwd() .. M.config.doc_dir, 'p')
     end
 
-    local file = vim.fn.getcwd() .. '/docs/' .. file_name .. '.md'
+    local file = vim.fn.getcwd() .. M.config.doc_dir .. '/' .. file_name .. '.md'
     if not file_exists(file) then
         vim.fn.writefile(template, file)
     end

--- a/lua/adr/init.lua
+++ b/lua/adr/init.lua
@@ -11,7 +11,7 @@ end
 
 M.config = {
     template_dir = vim.fs.dirname(debug.getinfo(1).source:sub(2)) .. "/../../templates",
-    doc_dir = '/docs',
+    doc_dir = 'docs',
 }
 
 M.setup = function(config)


### PR DESCRIPTION
Hi!

Wanting to use this plugin, while retaining any existing adr markdown files, I made a small change to your plugin. In this change a new parameter `doc_dir` is added to the config, allowing the user to change where the new files will be created. 
Locally, I've set it to `/doc/adr/`. This directory was automatically created in projects where the directory did not exist and the file was added as expected.

Please let me know what you think of this change and if anything should be change. (first lua plugin commit for me, but don´t hold back :) ) 